### PR TITLE
fix: remove redundant 'poetry add pytest' from test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,5 @@ jobs:
         run: |
           pip install poetry
           poetry install
-          poetry add pytest
       - name: run tests
         run: poetry run pytest .


### PR DESCRIPTION
All five test matrix jobs currently fail in the "Install dependencies" step:

    Incompatible constraints in requirements of edit-distance (1.0.7):
    pytest (>=9.0.3,<10.0.0)
    pytest (>=8.4.2,<9.0.0)

The unpinned `poetry add pytest` in `build.yml` resolves to the latest release — now that pytest 9 is out, it conflicts with the `pytest = "^8.4.2"` dev dependency in `pyproject.toml`. The line is redundant anyway since `poetry install` already installs pytest, so this just removes it.

Also seen failing on #60, which is unrelated to that PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)