### PR TITLE
fix: packaging metadata (license field, py.typed location)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/belambert/edit-distance"
 repository = "https://github.com/belambert/edit-distance"
 documentation = "https://edit-distance.readthedocs.io/"
 keywords=["edit", "distance", "editdistance", "levenshtein"]
-license = "MIT"
+license = "Apache-2.0"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
         "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Computing edit distance on arbitrary Python sequences"
 authors = ["Ben Lambert <blambert@gmail.com>"]
 readme = "README.md"
 packages = [{include = "edit_distance"}]
-include = ["py.typed"]
 homepage = "https://github.com/belambert/edit-distance"
 repository = "https://github.com/belambert/edit-distance"
 documentation = "https://edit-distance.readthedocs.io/"


### PR DESCRIPTION
Two packaging metadata fixes:

1. **License field**: `pyproject.toml` declared `license = "MIT"`, but the LICENSE file, source headers, and the trove classifier all say Apache 2.0. The field now reads `Apache-2.0`, so the wheel's `License:` metadata matches the classifier.

2. **PEP 561 marker**: `py.typed` sat at the repo root, so it was never installed inside the package and type checkers treated the published distribution as untyped. It now lives at `edit_distance/py.typed`, where poetry picks it up automatically via the `packages` include; the now-redundant `include = ["py.typed"]` entry is removed.

Verified with `poetry build`: the wheel and sdist both contain `edit_distance/py.typed`, and wheel METADATA reports `License: Apache-2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)