### PR TITLE
fix: bump version to 1.0.9 and derive release version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build poetry
+      # the release tag is the single source of truth for the version, so a
+      # forgotten pyproject.toml bump can't produce a duplicate wheel
+      - name: Set version from release tag
+        run: poetry version "${GITHUB_REF_NAME#v}"
       - name: Build package
         run: python -m build
       - name: Publish package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "edit-distance"
-version = "1.0.7"
+version = "1.0.9"
 description = "Computing edit distance on arbitrary Python sequences"
 authors = ["Ben Lambert <blambert@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Fixes #67 — the `1.0.8` release never made it to PyPI.

## Root cause

The `v1.0.8` release triggered the `upload to pypi` workflow, but it [failed](https://github.com/belambert/edit-distance/actions/runs/27248516466) with:

```
400 File already exists ('edit_distance-1.0.7-py3-none-any.whl')
```

`pyproject.toml` was never bumped — it still declared `version = "1.0.7"` at the `v1.0.8` tag (and on `main`), so the build produced a `1.0.7` wheel that PyPI rejected as a duplicate.

## Changes

1. **Bump `pyproject.toml` to `1.0.9`.** Releasing from current `main` (rather than re-cutting `1.0.8` from the old tag) so the publish also includes the packaging-metadata fix from #64 and other changes merged since the tag.
2. **Derive the release version from the git tag.** `release.yml` now runs `poetry version "${GITHUB_REF_NAME#v}"` before building, making the tag the single source of truth. A forgotten `pyproject.toml` bump can no longer produce a duplicate wheel — whatever `vX.Y.Z` tag you release is what gets published.

## After merge

Cut a `v1.0.9` release to trigger the PyPI publish.