### PR TITLE
build: migrate from Poetry to uv with PEP 621 + VCS-derived versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+        with:
+          fetch-depth: 0  # hatch-vcs needs tags to derive the version
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
       - name: install dependencies
-        run: |
-          pip install poetry
-          poetry install --with=dev
+        run: uv sync
       - name: lint with pylint
         run: make lint
       - name: check types with mypy
@@ -38,13 +38,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        with:
+          fetch-depth: 0  # hatch-vcs needs tags to derive the version
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          pip install poetry
-          poetry install
+        run: uv sync
       - name: run tests
-        run: poetry run pytest .
+        run: uv run pytest .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,21 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Python
-        uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build poetry
-      # the release tag is the single source of truth for the version, so a
-      # forgotten pyproject.toml bump can't produce a duplicate wheel
-      - name: Set version from release tag
-        run: poetry version "${GITHUB_REF_NAME#v}"
+          fetch-depth: 0  # hatch-vcs derives the version from the release tag
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.x"
       - name: Build package
-        run: python -m build
+        run: uv build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,12 @@ edit_distance.egg-info
 dist
 build
 .coverage
+coverage.xml
 venv
+.venv
+__pycache__
+.mypy_cache
+.pytest_cache
+.hypothesis
+poetry.lock
+uv.lock

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: lint typecheck format isort pyupgrade test ci check
 
 lint:
-	poetry run pylint edit_distance
+	uv run pylint edit_distance
 
 typecheck:
-	poetry run mypy edit_distance test
+	uv run mypy edit_distance test
 
 format:
-	poetry run black --check --diff edit_distance test
+	uv run black --check --diff edit_distance test
 
 isort:
-	poetry run isort --check-only --diff edit_distance test
+	uv run isort --check-only --diff edit_distance test
 
 pyupgrade:
-	poetry run pyupgrade --py39-plus edit_distance/*.py test/*.py
+	uv run pyupgrade --py39-plus edit_distance/*.py test/*.py
 
 test:
-	poetry run pytest --cov=. --cov-report=xml .
+	uv run pytest --cov=. --cov-report=xml .
 
 ci: lint typecheck format isort pyupgrade test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,52 +1,60 @@
-[tool.poetry]
+[project]
 name = "edit-distance"
-version = "1.0.9"
+dynamic = ["version"]
 description = "Computing edit distance on arbitrary Python sequences"
-authors = ["Ben Lambert <blambert@gmail.com>"]
+authors = [{ name = "Ben Lambert", email = "blambert@gmail.com" }]
 readme = "README.md"
-packages = [{include = "edit_distance"}]
-homepage = "https://github.com/belambert/edit-distance"
-repository = "https://github.com/belambert/edit-distance"
-documentation = "https://edit-distance.readthedocs.io/"
-keywords=["edit", "distance", "editdistance", "levenshtein"]
+requires-python = ">=3.9"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
+keywords = ["edit", "distance", "editdistance", "levenshtein"]
 classifiers = [
-	"Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Text Processing",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Text Processing",
+    "Topic :: Utilities",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+[project.urls]
+Homepage = "https://github.com/belambert/edit-distance"
+Repository = "https://github.com/belambert/edit-distance"
+Documentation = "https://edit-distance.readthedocs.io/"
 
-[tool.poetry.group.dev.dependencies]
-black = "^25.9.0"
-coverage = "^7.10.7"
-pylint = "^3.3.8"
-mypy = "^1.18.2"
-pytest = "^8.4.2"
-pytest-cov = "^7.0.0"
-unittest-xml-reporting = "^3.2.0"
-isort = "^6.0.1"
-pyupgrade = "^3.15.0"
-hypothesis = ">=6"
+[project.scripts]
+edit-distance = "edit_distance.edit_distance:main"
+
+[dependency-groups]
+dev = [
+    "black>=25.9.0,<26",
+    "coverage>=7.10.7,<8",
+    "pylint>=3.3.8,<4",
+    "mypy>=1.18.2,<2",
+    "pytest>=8.4.2,<9",
+    "pytest-cov>=7.0.0,<8",
+    "unittest-xml-reporting>=3.2.0,<4",
+    "isort>=6.0.1,<7",
+    "pyupgrade>=3.15.0,<4",
+    "hypothesis>=6",
+]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.poetry.scripts]
-edit-distance = "edit_distance.edit_distance:main"
+# version is derived from the git tag, so a release never needs a manual bump
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.wheel]
+packages = ["edit_distance"]
 
 [tool.pylint."messages control"]
 disable = [


### PR DESCRIPTION
## Summary

Migrates the project off Poetry to a standard PEP 621 `[project]` layout built with **hatchling**, managed with **uv**. The package version is now derived from the git tag via **hatch-vcs**, so `pyproject.toml` no longer carries a version field at all.

This is the follow-up to #68: it eliminates the root cause of #67 structurally — a forgotten version bump is now impossible, because there's nothing to bump.

## Changes

- **`pyproject.toml`**: `[tool.poetry]` → PEP 621 `[project]`; `dynamic = ["version"]` with `[tool.hatch.version] source = "vcs"`. Dev deps moved to a PEP 735 `[dependency-groups]` dev group (caret bounds preserved, so tool behavior is unchanged). SPDX `license = "Apache-2.0"` + `license-files`; explicit `packages = ["edit_distance"]` so `py.typed` ships.
- **`build.yml` / `release.yml`**: use `astral-sh/setup-uv` + `uv sync` / `uv build` / `uv publish` instead of Poetry. Release no longer stamps the version (#68's workaround removed) — hatch-vcs reads it from the tag.
- Checkouts use `fetch-depth: 0` so hatch-vcs can see tags.
- **`Makefile`**: `poetry run` → `uv run`.
- **`.gitignore`**: ignore lock files and local caches; removed the stale `poetry.lock`/`uv.lock`.

## Validation (local)

- `uv sync` + `make ci` (pylint, mypy, black, isort, pyupgrade, pytest): all pass.
- `uv build` on the branch → `1.0.10.dev…` (dev version, distance from last tag).
- Tagging an exact commit → clean version with no `pyproject.toml` change (verified a `v99.0.0` tag builds `edit_distance-99.0.0`).

## Note

The next release just needs a `vX.Y.Z` tag/release — no file edits. `docs/conf.py` still hardcodes an old `0.2.3` version; left as-is to keep this PR focused (can wire it to the package version separately).